### PR TITLE
Simplify logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,6 @@ primusOptions       | Options for the Primus Server             | `{}`
 
 > [See primus options here](https://github.com/primus/primus#getting-started)
 
-## Usage with HtmlWebpackPlugin
-Depending on the [inject option](https://github.com/jantimon/html-webpack-plugin#options) provided to `HtmlWebpackPlugin`, `primus-client-webpack-plugin` exposes the `primus-client` file in different ways.
-
-`inject` | placement
------- | ---------
-true   | file is inserted at the bottom of the `<body />`, after all other assets
-"body" | file is inserted at the bottom of the `<body />`, after all other assets
-"head" | file is inserted at the bottom of the `<head />`, after all other assets
-false  | file is exposed in `htmlWebpackPlugin.files.js`, along with all other JavaScript assets
-
 ## Caveats
 
 `primus.library()` generates a UMDish style file but it doesn't seem to work being bundled with Webpack, instead a global `Primus` constructor is added. If you want to `require/import` Primus you will need to [shim](https://github.com/webpack/docs/wiki/shimming-modules#plugin-provideplugin) it in your Webpack config.

--- a/index.js
+++ b/index.js
@@ -62,37 +62,9 @@ class PrimusWebpackPlugin {
           );
           const publicPath = compilation.outputOptions.publicPath || "";
 
-          if (!htmlPluginData.plugin.options.inject) {
-            // We are putting Primus script before other JavaScript files
-            // because we are expecting other bundles to use Primus
-            htmlPluginData.assets.js.unshift(`${publicPath}${filename}`)
-          }
-
-          cb(null, htmlPluginData);
-        }
-      );
-      
-      compilation.plugin(
-        'html-webpack-plugin-before-html-processing',
-        (htmlPluginData, cb) => {
-          const filename = this.options.filename.replace(
-            '[hash]',
-            compilation.hash
-          );
-          const publicPath = compilation.outputOptions.publicPath || "";
-          const scriptTag = `<script type="text/javascript" src="${publicPath}${filename}"></script>`;
-
-          if (htmlPluginData.plugin.options.inject === 'head') {
-            htmlPluginData.html = htmlPluginData.html.replace(
-              '</head>',
-              scriptTag + '</head>'
-            );
-          } else if (htmlPluginData.plugin.options.inject !== false) {
-            htmlPluginData.html = htmlPluginData.html.replace(
-              '</body>',
-              scriptTag + '</body>'
-            );
-          }
+          // We are putting Primus script before other JavaScript files
+          // because we are expecting other bundles to use Primus
+          htmlPluginData.assets.js.unshift(`${publicPath}${filename}`)
 
           cb(null, htmlPluginData);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primus-client-webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Build client side primus script and add to build assets",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
By adding our primus-client script to htmlPluginData.assets.js, we allow
HTMLWebpackPlugin to handle how the script should be included.